### PR TITLE
Add *.retry to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 hosts
+*.retry


### PR DESCRIPTION
Ansible generates <playbook>.retry files that should be
ignored

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>