### PR TITLE
Fix install policy.json task

### DIFF
--- a/cri-o.yml
+++ b/cri-o.yml
@@ -141,6 +141,7 @@
       shell: |
               cd /root/src/github.com/kubernetes-incubator/cri-o && \
               cp test/policy.json /etc/containers/policy.json
+      when: ansible_distribution == 'Ubuntu'
     - name: build CNI stuff
       shell: |
               cd /root/src/github.com/containernetworking/plugins && \


### PR DESCRIPTION
task: install policy.json in Ubuntu
was running in all distros.

Fixes #7

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>