### PR TITLE
make playbook more idempotent when linking runc

### DIFF
--- a/cri-o.yml
+++ b/cri-o.yml
@@ -125,7 +125,7 @@
               make install
 
     - name: link runc
-      file: src=/usr/local/sbin/runc dest=/usr/bin/runc state=link
+      file: src=/usr/local/sbin/runc dest=/usr/bin/runc state=link force=yes
 
     - name: build cri-o
       shell: |


### PR DESCRIPTION
Signed-off-by: Aaron Weitekamp <aweiteka@redhat.com>

Without this I was getting this error when running playbook a second time:

```
TASK [link runc] *************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "gid": 0, "group": "root", "mode": "0755", "msg": "refusing to convert between file and link for /usr/bin/runc", "owner": "root", "path": "/usr/bin/runc", "secontext": "system_u:object_r:container_runtime_exec_t:s0", "size": 7279632, "state": "file", "uid": 0}
    to retry, use: --limit @/vagrant/cri-o.retry

PLAY RECAP *******************************************************************************
localhost                  : ok=13   changed=2    unreachable=0    failed=1
```