### PR TITLE
bump cri-o version to v1.8.0

### DIFF
--- a/cri-o.yml
+++ b/cri-o.yml
@@ -110,7 +110,7 @@
       git:
         repo: https://github.com/kubernetes-incubator/cri-o
         dest: /root/src/github.com/kubernetes-incubator/cri-o
-        version: kube-1.6.x
+        version: v1.8.0
 
     - name: clone CNI
       git:


### PR DESCRIPTION
The kube-1.6.x branch doesn't exists anymore