### PR TITLE
fixes to get the playbooks working in latest centos (7.7.1908) with k8s 1.16 and crio

### DIFF
--- a/cri-o.yml
+++ b/cri-o.yml
@@ -250,10 +250,23 @@
       command: "sysctl -p"
       ignore_errors: true
 
+    - name: kubelet_extra_args copied to /etc/default/kubelet
+      copy:
+        content: "KUBELET_EXTRA_ARGS=--feature-gates=\"AllAlpha=false,RunAsGroup=true\" --container-runtime=remote --cgroup-driver=cgroupfs --container-runtime-endpoint='unix:///var/run/crio/crio.sock' --runtime-request-timeout=5m"
+        force: yes
+        dest: /etc/default/kubelet
+
     - name: systemd dropin for kubeadm
-      shell: |
-              sh -c 'echo "[Service]
-              Environment=\"KUBELET_EXTRA_ARGS=--enable-cri=true --container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint /var/run/crio.sock --container-runtime-endpoint /var/run/crio.sock\"" > /etc/systemd/system/kubelet.service.d/0-crio.conf'
+      copy:
+        content: |
+              [Service]
+              Environment=-/etc/default/kubelet
+        dest: /etc/systemd/system/kubelet.service.d/0-crio.conf
+        force: yes
+
+    - name: just force systemd to reread configs
+      systemd:
+        daemon_reload: yes
 
     - name: flush iptables
       command: "iptables -F"

--- a/cri-o.yml
+++ b/cri-o.yml
@@ -35,6 +35,12 @@
         - wget
       when: ansible_distribution == 'Fedora'
 
+    - name: install Epel repository
+      yum:
+        name: epel-release
+        state: latest
+      when: ansible_distribution == 'CentOS'
+
     - name: Make sure we have all required packages on RHEL/CentOS
       yum:
         name: "{{ item }}"
@@ -61,6 +67,16 @@
         - tar
         - wget
       when: ansible_distribution in ['RedHat', 'CentOS']
+
+    - name: Make sure we have all required packages on RHEL
+      yum:
+        name: "go-md2man"
+      when: ansible_distribution == 'RedHat'
+
+    - name: Make sure we have all required packages on CentOS
+      yum:
+        name: "golang-github-cpuguy83-go-md2man"
+      when: ansible_distribution == 'CentOS'
 
     - name: Make sure we have all required packages on Ubuntu
       package:
@@ -110,7 +126,7 @@
       git:
         repo: https://github.com/kubernetes-incubator/cri-o
         dest: /root/src/github.com/kubernetes-incubator/cri-o
-        version: kube-1.6.x
+        version: release-1.16
 
     - name: clone CNI
       git:
@@ -129,12 +145,25 @@
 
     - name: build cri-o
       shell: |
+              export GOPATH=/root && \
+              export GOBIN=/usr/local/go/bin && \
+              export PATH=/usr/local/go/bin:$PATH && \
               cd /root/src/github.com/kubernetes-incubator/cri-o && \
-              make install.tools && \
               make && \
               make install && \
               make install.systemd && \
               make install.config
+
+    - name: clone conmon dependency
+      git:
+        repo: http://github.com/containers/conmon
+        dest: /root/src/github.com/conmon
+  
+    - name: build and install conmon
+      shell: |
+              cd /root/src/github.com/conmon && \
+              make && \
+              make install
 
     - name: install policy.json in Ubuntu
       shell: |
@@ -145,7 +174,7 @@
     - name: build CNI stuff
       shell: |
               cd /root/src/github.com/containernetworking/plugins && \
-              ./build.sh && \
+              ./build_linux.sh && \
               mkdir -p /opt/cni/bin && \
               cp bin/* /opt/cni/bin/
 
@@ -159,15 +188,22 @@
 
     - name: run with overlay2
       replace:
-        regexp: 'storage_driver = ""'
+        regexp: '^#storage_driver = "overlay"'
         replace: 'storage_driver = "overlay2"'
+        name: /etc/crio/crio.conf
+        backup: yes
+
+    - name: change cgroup_manager to cgroupfs
+      replace:
+        regexp: '^cgroup_manager = "systemd"'
+        replace: 'cgroup_manager = "cgroupfs"'
         name: /etc/crio/crio.conf
         backup: yes
 
     - name: add overlay2 storage opts on RHEL/CentOS
       lineinfile:
         dest: /etc/crio/crio.conf
-        line: '"overlay2.override_kernel_check=1"'
+        line: 'storage_option = [ "overlay2.override_kernel_check=1" ]'
         insertafter: 'storage_option = \['
         regexp: 'overlay2\.override_kernel_check=1'
         state: present

--- a/install/golang.yml
+++ b/install/golang.yml
@@ -7,10 +7,10 @@
 
 - name: install Golang upstream
   unarchive:
-    src: "https://golang.org/dl/go1.8.3.linux-amd64.tar.gz"
+    src: "https://golang.org/dl/go1.13.linux-amd64.tar.gz"
     dest: "/usr/local"
     remote_src: True
-  when: '"go1.8.3" not in go_version.stdout'
+  when: '"go1.13" not in go_version.stdout'
 
 - name: Set custom Golang path in RHEL/CentOS/Fedora
   lineinfile:


### PR DESCRIPTION
Multiple fixes for upgrading go and get the playbooks working in latest CentOS (7.7.1908) together with Kubernetes 1.16

Signed-off-by: Pedro Ibáñez <pedro@redhat.com>

Changelog:
- Upgraded go from go1.8.3 to go1.13
- Install EPEL repo for CentOS as it is needed golang-github-cpuguy83-go-md2man
- Fixed the cri-o version release from kube-1.6.x to release-1.16
- Use proper PATH, GOPATH and GOBIN for building cri-o (even removed the make.install tools as it doesn't exist any more)
- Cloned and compiled the conmon dependency needed by cri-o
- Renamed the build.sh from containernetworking/plugins to build_linux.sh
- Multiples changes for the /etc/crio/crio.conf as the example configuration file contained different parameters the regular expressions were not working anymore.