### PR TITLE
Populate an OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - runcom
+reviewers:
+  - runcom
+  - aweiteka
+  - mrunalp


### PR DESCRIPTION
Hi, I'm from a team maintaining OpenShift Prow instance which is configured to perform some actions on this repo. Some of the actions need `OWNERS` file, so I'm submitting one with names of the people who seem to be active in PRs to this repo.

xref: https://github.com/openshift/release/issues/6092